### PR TITLE
Fix/webdriver manager

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -69,6 +69,7 @@
     "gulp-inject": "^1.0.2",
     "gulp-if": "^1.2.5",
     "gulp-protractor": "0.0.12",
+		"protractor": "^3.3.0",
     "jshint-stylish": "^1.0.0",
     "main-bower-files": "^2.4.1",
     "mocha-jenkins-reporter": "^0.1.2",

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -69,7 +69,7 @@
     "gulp-inject": "^1.0.2",
     "gulp-if": "^1.2.5",
     "gulp-protractor": "0.0.12",
-		"protractor": "^3.3.0",
+    "protractor": "^3.3.0",
     "jshint-stylish": "^1.0.0",
     "main-bower-files": "^2.4.1",
     "mocha-jenkins-reporter": "^0.1.2",


### PR DESCRIPTION
Use the protractor binary for webdriver-manager update to support errorless npm install on windows machines
